### PR TITLE
Update package.json license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "coveralls": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --dir ./reports/coveralls/coverage --report lcovonly -- -R spec && cat ./reports/coveralls/coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./reports/coveralls"
   },
   "main": "./lib",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/validate-io/json.git"
@@ -44,11 +45,5 @@
     "istanbul": "^0.3.0",
     "jshint": "2.x.x",
     "jshint-stylish": "^1.0.0"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/MIT"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Currently, `licenses ` is not recognised by npm, see https://www.npmjs.com/package/validate.io-json sidebar, it currently says: "license: none"